### PR TITLE
fix: テーブルヘッダの文字色を白に修正

### DIFF
--- a/assets/styles/override.scss
+++ b/assets/styles/override.scss
@@ -166,8 +166,8 @@ table td {
 }
 
 table th {
-    background-color: var(--primary-medium);
-    color: var(--primary-color);
+    background-color: var(--primary-color);
+    color: #fff;
     font-weight: 600;
 }
 


### PR DESCRIPTION
## Summary
- テーブルヘッダの背景色がプライマリカラー(#009988)で文字色も緑になり読めなかった問題を修正
- 文字色を `#fff` に変更して視認性を確保

## Test plan
- [ ] `/services/price/` ページでテーブルヘッダが白文字で表示されることを確認
- [ ] ダークテーマでも視認性に問題がないことを確認