### PR TITLE
fix: フッターからメールアドレスを削除（スパム対策）

### DIFF
--- a/data/ja/author.yaml
+++ b/data/ja/author.yaml
@@ -7,7 +7,7 @@ greeting: "Welcome to"
 image: "images/author/iam.png"
 # give your some contact information. they will be used in the footer
 contactInfo:
-  email: "contact@nexa-eng.com"
+#  email: "contact@nexa-eng.com"
 #  phone: "+0123456789"
   github: "nexa-eng"
 #  linkedin: johndoe


### PR DESCRIPTION
## Summary
- フッターに表示されていた `contact@nexa-eng.com` をスパム対策のため削除
- `data/ja/author.yaml` の `email` フィールドをコメントアウト

## Test plan
- [ ] トップページのフッターにメールアドレスが表示されていないことを確認
- [ ] プライバシーポリシーページのお問い合わせ先は引き続き表示されることを確認